### PR TITLE
fixing import paths

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,11 +6,5 @@
 		]
 	},
 	"ignore": "test",
-	"package": [
-		{
-			"path": "github.com/af2570/lsproject/cmd/going_going_gone",
-			"revision": ""
-		}
-	],
-	"rootPath": "github.com/af2570/lsproject"
+	"rootPath": "github.com/af2570/lsproject/cmd"
 }


### PR DESCRIPTION
I fixed the import paths in the vendor.json file to more accurately reflect the root directory of Go packages.